### PR TITLE
add spherical_dist function

### DIFF
--- a/dyntrigger/hifi/AssociateBackgroundPIR.py
+++ b/dyntrigger/hifi/AssociateBackgroundPIR.py
@@ -85,4 +85,4 @@ def run_associate(
 
     tele_background_pir_df.to_csv(out_file, index=False)
 
-    return tele_background_pir_df
+    return None

--- a/dyntrigger/hifi/ConfidenceLevel.py
+++ b/dyntrigger/hifi/ConfidenceLevel.py
@@ -60,4 +60,4 @@ def run_cl(
             'time', 'confidence_level_value'])
     cl_dataframe.to_csv(out_file, index=False)
 
-    return cl_dataframe
+    return None

--- a/dyntrigger/utils/basic_utils.py
+++ b/dyntrigger/utils/basic_utils.py
@@ -40,6 +40,23 @@ def peak_dynamic_stress(tele_event_tr, shear_wave_velocity, te_b, te_e, shear_mo
     return dynamic_stress
 
 
+def spherical_dist(lon1,lat1,lon2,lat2): #degree
+    """
+    Calculate the spherical distance between two points on the earth.
+    Using the Spherical Cosine Equation.
+    For spherical triangle ABC, the corresponding sides are a,b and c.
+    cos(a) = cos(b)*cos(c)+sin(b)sin(c)cos(A)
+    For B(lon1,lat1) and C(lon2,lat2), set A(0,90).
+    Then:
+    cos(a)=cos(90-lat2)*cos(90-lat1)+sin(90-lat1)*sin(90-lat2)*cos(lon2-lon1)
+    cos(a)=sin(lat2)*sin(lat1)+cos(lat1)*cos(lat2)*cos(lon2-lon1)
+    """
+    lon1, lat1, lon2, lat2 =map(radians,[lon1,lat1,lon2,lat2])
+    a=acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(lon2 - lon1))
+    r = 6371 #Radius of the Earth
+    return a*r, a*r /111
+
+
 def haversine(lon1, lat1, lon2, lat2):  # degree
     """
     Calculate the great circle distance between two points

--- a/dyntrigger/utils/preprocess_tele_catalog.py
+++ b/dyntrigger/utils/preprocess_tele_catalog.py
@@ -146,7 +146,7 @@ def begin_v_end_v(catalog_file, sta_lat, sta_lon, tb, vel_begin, vel_end):
             dist_km = dat.iloc[i]['dist(km)']
             distance_in_degree = dist_km / 111
         else:
-            dist_km, distance_in_degree = haversine(
+            dist_km, distance_in_degree = spherical_dist(
                 sta_lon, sta_lat, event_lon, event_lat)
 
         a_time = abs_arrival_time(ot, depth, distance_in_degree)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(pth_file, 'w') as f:
 print('>>> Install packages...')
 try:
     os.system('pip install -r requirements.txt')
-    # os.system('pip install numy')
+    # os.system('pip install numpy')
     # os.system('pip install pandas')
     # os.system('pip install scipy')
     # os.system('pip install obspy')


### PR DESCRIPTION
1. Add spherical_dist(lon1, lat1, lon2, lat2) function, which can be easily understood by the reader.
2. For function ConfidenceLevel.run_cl and AssociateBackgroundPIR.run_associate, there are no need to return data.
3. Correct 'nump' to 'numpy' in setup.py